### PR TITLE
[CLEANUP] Remove quotes in allowedFileTypes

### DIFF
--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -5,7 +5,7 @@ plugin.tx_solr {
       sys_file_metadata {
         initialization = HMMH\SolrFileIndexer\IndexQueue\FileInitializer
         indexer = HMMH\SolrFileIndexer\Indexer\FileIndexer
-        allowedFileTypes = 'pdf','doc','docx','xlsx'
+        allowedFileTypes = pdf,doc,docx,xlsx
         additionalPageIds = 0
 
         fields {
@@ -32,12 +32,12 @@ plugin.tx_solr {
           }
 
           description = description
-          
+
           keywords = SOLR_MULTIVALUE
           keywords {
             field = keywords
           }
-          
+
           author = creator
         }
       }

--- a/Documentation/ForDevelopers/Index.rst
+++ b/Documentation/ForDevelopers/Index.rst
@@ -23,7 +23,7 @@ TypoScript Configuration
         sys_file_metadata {
           initialization = HMMH\SolrFileIndexer\IndexQueue\FileInitializer
           indexer = HMMH\SolrFileIndexer\Indexer\FileIndexer
-          allowedFileTypes = 'pdf','doc','docx','xlsx'
+          allowedFileTypes = pdf,doc,docx,xlsx
 
           fields {
             title = title
@@ -71,5 +71,5 @@ Specifies the allowed file types to be indexed.
       string
 
 :aspect:`Default`
-      'pdf','doc','docx','xlsx'
+      pdf,doc,docx,xlsx
 

--- a/Readme.md
+++ b/Readme.md
@@ -31,7 +31,7 @@ plugin.tx_solr {
       sys_file_metadata {
         initialization = HMMH\SolrFileIndexer\IndexQueue\FileInitializer
         indexer = HMMH\SolrFileIndexer\Indexer\FileIndexer
-        allowedFileTypes = 'pdf','doc','docx','xlsx'
+        allowedFileTypes = pdf,doc,docx,xlsx
 
         fields {
           title = title


### PR DESCRIPTION
For backwards compatibility i added `getArrayOfAllowedFileTypes()`