### PR TITLE
remove deprecated DBAL call

### DIFF
--- a/Classes/IndexQueue/Queue.php
+++ b/Classes/IndexQueue/Queue.php
@@ -100,7 +100,7 @@ class Queue extends \ApacheSolrForTypo3\Solr\IndexQueue\Queue
             );
         }
 
-        return empty($connection->errorInfo());
+        return true;
     }
 
     /**


### PR DESCRIPTION
DBAL errorInfo is deprecated. Error informations are available via exceptions.