### PR TITLE
[TASK] Mark nullable parameters explicitly as nullable

### DIFF
--- a/Classes/IndexQueue/FileInitializer.php
+++ b/Classes/IndexQueue/FileInitializer.php
@@ -54,8 +54,8 @@ class FileInitializer extends AbstractInitializer
      * @param PagesRepository|null     $pagesRepository
      */
     public function __construct(
-        QueueItemRepository $queueItemRepository = null,
-        PagesRepository $pagesRepository = null
+        ?QueueItemRepository $queueItemRepository = null,
+        ?PagesRepository $pagesRepository = null
     )
     {
         parent::__construct($queueItemRepository, $pagesRepository);


### PR DESCRIPTION
Implicitly marking parameters as nullable is deprecated and throws a "PHP Runtime Deprecation Notice" since PHP 8.4.