### PR TITLE
[TASK] Allow all file types when allowedFileTypes is empty

### DIFF
--- a/Classes/Service/ItemQueueWorker.php
+++ b/Classes/Service/ItemQueueWorker.php
@@ -138,7 +138,7 @@ class ItemQueueWorker
 
             foreach ($collections as $collection) {
                 foreach ($collection as $file) {
-                    if (!in_array($file->getExtension(), $allowedFileTypes)) {
+                    if ($allowedFileTypes && !in_array($file->getExtension(), $allowedFileTypes)) {
                         continue;
                     }
                     $metadata = $this->getMetadataFromFile($file);


### PR DESCRIPTION
# Issue

Prior to 69e9d593129817fe484254148135f61dc9e810fa it was possible to allow all file types by setting an empty `allowedFileTypes`.

This MR restores this behaviour.

# Changes

The FileExtension check is only performed if `allowedFileTypes` has a value set.

Since there is a default value for `allowedFileTypes` provided by the extension, it shouldn't change anything for most installations, unless they explicitly removed the value:
```
plugin.tx_solr.index.queue.sys_file_metadata.allowedFileTypes >
```