### PR TITLE
[TASK] Remove items from the fileindexer queue when files are deleted

### DIFF
--- a/Classes/Resource/IndexItemRepository.php
+++ b/Classes/Resource/IndexItemRepository.php
@@ -214,4 +214,18 @@ class IndexItemRepository
         $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable(self::FILE_TABLE);
         $connection->truncate(self::FILE_TABLE);
     }
+
+    /**
+     * @param int $itemUid
+     * @return void
+     */
+    public function deleteItemsByUid(int $itemUid): void
+    {
+        $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::FILE_TABLE);
+        $queryBuilder->delete(self::FILE_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('item_uid', $itemUid)
+            )
+            ->executeStatement();
+    }
 }

--- a/Classes/Service/GarbageCollector.php
+++ b/Classes/Service/GarbageCollector.php
@@ -119,6 +119,7 @@ class GarbageCollector implements SingletonInterface
     protected function collectGarbage(int $uid): void
     {
         $this->getGarbageHandler()->collectGarbage(MetadataRepository::FILE_TABLE, $uid);
+        $this->indexItemRepository->deleteItemsByUid($uid);
     }
 
     /**


### PR DESCRIPTION
After the removal of a file, the base SOLR extension is responsible for removing corresponding Metadatas from its core(s) and index queue, but there are still references stored in the `tx_solrfileindexer_items` table.

It would be actually pretty easy to remove all corresponding records in the GarbageCollector.