### PR TITLE
[BUGFIX] Allow indexing of locked items

### DIFF
--- a/Classes/Resource/IndexItemRepository.php
+++ b/Classes/Resource/IndexItemRepository.php
@@ -182,7 +182,6 @@ class IndexItemRepository
             $queryBuilder->expr()->eq(BaseUtility::getIndexItemLanguageField(), $sysLanguageUid),
             $queryBuilder->expr()->eq('item_type', $queryBuilder->createNamedParameter($type)),
             $queryBuilder->expr()->eq('indexing_configuration', $queryBuilder->createNamedParameter($configurationName)),
-            $queryBuilder->expr()->eq(BaseUtility::getIndexItemEditlockField(), 0)
         ];
 
         return $queryBuilder->select('*')


### PR DESCRIPTION
# Issue

The indexer locks all records of a collection before iterating through all the files of the collection and insert or unlock the corresponding records.

For large collections, this can take quite a while. During that time (or if the worker was interrupted before completion), the indexer will not be able to find the corresponding files, but will still mark the items as processed in the SOLR queue.

# Fix

IMHO `findIndexableItem` doesn't need to check the locking status of items. Should some to-be-deleted items be added to the SOLR queue, they will still be removed by the `GarbageCollector` at the end of the process.