### PR TITLE
[BUGFIX] Run the garbage collector only for specified collections

### DIFF
--- a/Classes/Resource/IndexItemRepository.php
+++ b/Classes/Resource/IndexItemRepository.php
@@ -108,17 +108,26 @@ class IndexItemRepository
     }
 
     /**
+     * @param array|null $collectionUids
+     *
      * @return \mixed[][]
      * @throws \Doctrine\DBAL\Exception
      */
-    public function findLockedEntries()
+    public function findLockedEntries(?array $collectionUids)
     {
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)->getQueryBuilderForTable(self::FILE_TABLE);
+
+        $constraints = [
+            $queryBuilder->expr()->eq(BaseUtility::getIndexItemEditlockField(), 1)
+        ];
+
+        if (!empty($collectionUids)){
+            $constraints[] = $queryBuilder->expr()->in('collection', $collectionUids);
+        }
+
         return $queryBuilder->select('*')
             ->from(self::FILE_TABLE)
-            ->where(
-                $queryBuilder->expr()->eq(BaseUtility::getIndexItemEditlockField(), 1)
-            )
+            ->where(...$constraints)
             ->executeQuery()
             ->fetchAllAssociative();
     }

--- a/Classes/Service/GarbageCollector.php
+++ b/Classes/Service/GarbageCollector.php
@@ -48,13 +48,15 @@ class GarbageCollector implements SingletonInterface
     ) {}
 
     /**
+     * @param array|null $collectionUids
+     *
      * @return void
      * @throws \Doctrine\DBAL\Exception
      * @throws \TYPO3\CMS\Core\Exception\SiteNotFoundException
      */
-    public function removeObsoleteEntriesFromIndexes(): void
+    public function removeObsoleteEntriesFromIndexes(?array $collectionUids): void
     {
-        $obsoleteEntries = $this->indexItemRepository->findLockedEntries();
+        $obsoleteEntries = $this->indexItemRepository->findLockedEntries($collectionUids);
         $connectionAdapter = GeneralUtility::makeInstance(ConnectionAdapter::class);
         $siteRepository = GeneralUtility::makeInstance(SiteRepository::class);
         $siteFinder = GeneralUtility::makeInstance(SiteFinder::class);

--- a/Classes/Service/ItemQueueWorker.php
+++ b/Classes/Service/ItemQueueWorker.php
@@ -67,6 +67,8 @@ class ItemQueueWorker
     }
 
     /**
+     * @param array|null $collectionUids
+     *
      * @return void
      * @throws \Doctrine\DBAL\Exception
      */
@@ -98,7 +100,7 @@ class ItemQueueWorker
         }
 
         $garbageCollector = GeneralUtility::makeInstance(GarbageCollector::class);
-        $garbageCollector->removeObsoleteEntriesFromIndexes();
+        $garbageCollector->removeObsoleteEntriesFromIndexes($collectionUids);
     }
 
     /**


### PR DESCRIPTION
# Issue

It is possible to restrict the run of a `solr_file_indexer:item-queue-worker` to specific collections. Yet at the end of the process, the GarbageCollector will delete **all** locked items, even if they belong to another collection (e.g. one that is currently being processed).

## How to reproduce

1. Create two scheduler tasks `solr_file_indexer:item-queue-worker` with distinct `collections` options
2. Run those tasks in parallel
3. The first task that completes will remove all entries in `tx_solrfileindexer_items` currently locked by the other scheduler task

# Changes

The `removeObsoleteEntriesFromIndexes` was extended to respect the `$collectionUids` parameter if provided, similar to the `lock` method.