### PR TITLE
[TASK] Improve memory footprint of the itemQueueWorker

### DIFF
--- a/Classes/Service/ItemQueueWorker.php
+++ b/Classes/Service/ItemQueueWorker.php
@@ -44,9 +44,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class ItemQueueWorker
 {
-    /** @var array  */
-    protected array $items = [];
-
     /** @var SiteFinder */
     protected SiteFinder $siteFinder;
 
@@ -61,7 +58,8 @@ class ItemQueueWorker
         protected MetadataRepository $metadataRepository,
         protected FileCollectionRepository $fileCollectionRepository,
         protected FrontendEnvironment $frontendEnvironment,
-        protected QueueItemRepository $queueItemRepository
+        protected QueueItemRepository $queueItemRepository,
+        protected Queue $queue
     ) {
         $this->siteFinder = GeneralUtility::makeInstance(SiteFinder::class);
     }
@@ -76,25 +74,11 @@ class ItemQueueWorker
 
         foreach ($this->siteFinder->getAllSites() as $site) {
             foreach ($site->getLanguages() as $language) {
-                $collections = $this->loadFilesFromCollections($site, $language, $collectionUids);
+                $collections = $this->getCollections($site, $language, $collectionUids);
                 if (!empty($collections)) {
                     $this->generateItems($site, $language, $collections);
                 }
             }
-        }
-
-        /** @var Queue $queue */
-        $queue = GeneralUtility::makeInstance(Queue::class);
-
-        foreach ($this->items as $item) {
-            $this->indexItemRepository->save($item);
-            $queue->saveItemForRootpage(
-                MetadataRepository::FILE_TABLE,
-                $item['item_uid'],
-                $item['root'],
-                $item['indexing_configuration'],
-                []
-            );
         }
 
         $garbageCollector = GeneralUtility::makeInstance(GarbageCollector::class);
@@ -108,21 +92,15 @@ class ItemQueueWorker
      * @return \TYPO3\CMS\Core\Collection\AbstractRecordCollection[]|null
      * @throws \Doctrine\DBAL\Exception
      */
-    protected function loadFilesFromCollections(Site $site, SiteLanguage $language, ?array $collectionUids = null)
+    protected function getCollections(Site $site, SiteLanguage $language, ?array $collectionUids = null)
     {
-        $collections = $this->fileCollectionRepository->findForSolr($site->getRootPageId(), $language->getLanguageId(), $collectionUids);
-        if (!empty($collections)) {
-            foreach ($collections as $collection) {
-                $collection->loadContents();
-            }
-        }
-        return $collections;
+        return $this->fileCollectionRepository->findForSolr($site->getRootPageId(), $language->getLanguageId(), $collectionUids);
     }
 
     /**
      * @param Site         $site
      * @param SiteLanguage $language
-     * @param array        $collections
+     * @param \TYPO3\CMS\Core\Collection\AbstractRecordCollection[] $collections
      *
      * @return void
      * @throws \Doctrine\DBAL\Exception
@@ -131,22 +109,34 @@ class ItemQueueWorker
     {
         $solrConfiguration = $this->frontendEnvironment->getSolrConfigurationFromPageId($site->getRootPageId(), $language->getLanguageId());
         $indexingConfigurationNames = $solrConfiguration->getIndexQueueConfigurationNamesByTableName(MetadataRepository::FILE_TABLE);
+        $allowedFileTypesMap = [];
 
+        // get the allowedFileTypes for each indexConfigurationName
         foreach ($indexingConfigurationNames as $indexingConfigurationName) {
             $fileInitializer = InitializerFactory::createFileInitializerForRootPage($site->getRootPageId(), $indexingConfigurationName);
-            $allowedFileTypes = $fileInitializer->getArrayOfAllowedFileTypes();
+            $allowedFileTypesMap[$indexingConfigurationName] = $fileInitializer->getArrayOfAllowedFileTypes();
+        }
 
-            foreach ($collections as $collection) {
-                foreach ($collection as $file) {
+        foreach ($collections as $collection) {
+            // load items of the collection being processed
+            $collection->loadContents();
+
+            foreach ($collection as $file) {
+                // reinit metadata and result for every new file
+                $metadata = null;
+                $result = null;
+
+                foreach ($allowedFileTypesMap as $indexingConfigurationName => $allowedFileTypes) {
                     if (!empty($allowedFileTypes) && !in_array($file->getExtension(), $allowedFileTypes)) {
                         continue;
                     }
-                    $metadata = $this->getMetadataFromFile($file);
+                    $metadata ??= $this->getMetadataFromFile($file);
                     if (empty($metadata)) {
-                        continue;
+                        // skip the file processing entirely for all indexingConfigurations
+                        continue 2;
                     }
-                    $result = $this->prepareMetadata($language, $metadata);
-                    $this->items[] = [
+                    $result ??= $this->prepareMetadata($language, $metadata);
+                    $this->saveItem([
                         'root' => $site->getRootPageId(),
                         'item_uid' => $result['uid'],
                         'localized_uid' => $result['localized'],
@@ -154,10 +144,25 @@ class ItemQueueWorker
                         'sys_language_uid' => $language->getLanguageId(),
                         'changed' => $result['changed'],
                         'collection' => $collection->getUid(),
-                    ];
+                    ]);
                 }
             }
         }
+    }
+
+    /**
+     * @param array $item
+     * @return void
+     */
+    protected function saveItem(array $item):void {
+        $this->indexItemRepository->save($item);
+        $this->queue->saveItemForRootpage(
+            MetadataRepository::FILE_TABLE,
+            $item['item_uid'],
+            $item['root'],
+            $item['indexing_configuration'],
+            []
+        );
     }
 
     /**


### PR DESCRIPTION
# Issue

The current logic of the `itemQueueWorker` will fetch all files of all collections before saving them all in the `$items` array. When working with multiple large collections, it requires a lot of memory.

# Changes

- The logic was split, so each collections gets retrieved independently, and memory gets freed before processing the next collection
   - Contents of a collection are loaded in the `generateItems` method, and saved right after they are being processed
   - this removes the need for the `$items` array attribute in the `ItemQueueWorker`
   - The Queue gets injected in the `ItemQueueWorker` constructor
   - The method `loadFilesFromCollections` was renamed to `getCollections` to match new behaviour
- When working with multiple indexingConfigurations, we avoid re-fetching the same file (and corresponding metadatas) for distinct configurations
   - I don't think it makes a huge difference, but it just occured to me as I was rewriting `generateItems`

## Test environment

Our environment has one collection, which contains approximately 80.000 files. The collection is translated in two languages. The container running the task can use up to 4GB of RAM, and the PHP `max_memory` limit is set at 3GB.
 
Here's a before/after of the indexing of all available collections:

| Before | After |
| --- | --- |
| <img width="1344" height="200" alt="image" src="https://github.com/user-attachments/assets/4f2bdd4d-f1be-4ff4-b823-75d49b69066e" /> | <img width="1344" height="200" alt="image" src="https://github.com/user-attachments/assets/921a9734-782f-4d56-8640-af8470d85338" /> |
| Job gets interrupted after 45 minutes, with the fatal error `Allowed memory size of 3225419776 bytes exhausted (tried to allocate 83886080 bytes)` | Job succeeds after 3 hours |